### PR TITLE
docs: add MkDocs documentation website for bionemo_ir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ compile_commands.json
 
 # Personal, machine-specific agent instructions (see CLAUDE.md)
 CLAUDE.local.md
+
+# MkDocs build output (`mkdocs build -f website/mkdocs.yml`)
+website/site/

--- a/website/.rumdl.toml
+++ b/website/.rumdl.toml
@@ -1,0 +1,25 @@
+# Markdown lint config for the MkDocs sources under website/. Separate from
+# the root .rumdl.toml because the site links to pages that are generated at
+# build time (mkdocs-gen-files) and never exist on disk.
+[global]
+flavor = "gfm"
+
+[MD013]
+# Line length applies to prose, not to fenced code blocks.
+code-blocks = false
+
+[MD057]
+# API Reference and Developer Docs pages are virtual (generated at build
+# time), so relative links to them cannot exist on disk.
+enabled = false
+
+[MD060]
+# Align table cells and delimiter rows.
+enabled = true
+style = "aligned"
+
+[MD033]
+allowed-elements = ["div", "details", "summary"]
+
+[MD041]
+allow-preamble = true

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,40 @@
+# BioIR documentation website
+
+Source for the BioNeMo Inference Runtime (BioIR) documentation site, built
+with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) and
+[mkdocstrings](https://mkdocstrings.github.io/).
+
+## Preview locally
+
+From the repository root:
+
+```bash
+pip install -r website/requirements.txt
+mkdocs serve -f website/mkdocs.yml
+```
+
+Then open <http://127.0.0.1:8000> — it redirects to
+`/BioNeMo-Inference-Runtime/` because `site_url` carries the GitHub Pages
+project path. To produce the static site instead:
+
+```bash
+mkdocs build -f website/mkdocs.yml
+```
+
+The output lands in `website/site/` (git-ignored). The API reference is
+parsed statically by griffe, so building the site needs no GPU, torch, or
+Ray.
+
+## What lives where
+
+- `docs/` — hand-written pages (landing page, guides). This is the only
+  tracked content.
+- `scripts/gen_ref_pages.py` — generates one API-reference page per
+  `bionemo_ir` module at build time (virtual files, nothing on disk).
+- `scripts/import_docs.py` — imports the repo's top-level `docs/` tree into
+  the "Developer Docs" section at build time, rewriting links that point
+  outside `docs/` to absolute GitHub URLs. `docs/nv/` (internal process
+  docs) is excluded.
+
+Deployment (GitHub Pages via CI) is intentionally not wired up yet — see
+[plan.md](plan.md) for the next steps.

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -1,0 +1,98 @@
+# Quickstart
+
+Install BioNeMo Inference Runtime (BioIR) and fold your first sequence.
+
+## Prerequisites
+
+- A Linux machine with an NVIDIA GPU (driver 535 series or newer)
+- Docker with the NVIDIA container runtime
+
+## Install
+
+Clone the repo with submodules and LFS objects:
+
+```bash
+git lfs install \
+    && GIT_LFS_SKIP_SMUDGE=0 \
+    git clone --recurse-submodules \
+        https://github.com/NVIDIA-BioNeMo/BioNeMo-Inference-Runtime.git \
+    && cd BioNeMo-Inference-Runtime
+```
+
+Build the dev image and open a shell in it:
+
+```bash
+docker/dev.sh
+```
+
+The image carries all dependencies and the checkout is bind-mounted, so
+install the package once inside the container:
+
+```bash
+pip install --no-build-isolation -e '.[dev]'
+```
+
+## Fold a sequence
+
+Stage the Boltz-2 checkpoint and run the demo:
+
+```bash
+scripts/fetch_weights.sh --model boltz-2
+python examples/folding/run_demo.py --output-dir output
+```
+
+The demo parses sequences and MSAs, featurizes them, runs inference, and
+writes PDB/mmCIF plus a `{id}_scores.json` sidecar with pLDDT / pTM / ipTM.
+Checkpoints come from their upstream publishers; anything that cannot be
+fetched is skipped.
+
+## Use the Python API
+
+The same five-stage pipeline, in-process:
+
+```mermaid
+graph LR
+    A[Parser] --> B[Tokenizer] --> C[Feature generator]
+    C --> D[Folding engine] --> E[Writer]
+```
+
+```python
+from bionemo_ir.data.schemas import InputRequest, MSARecord, Polymer
+from bionemo_ir.pipeline.processor.engine_proc import (
+    EngineProcessorConfig,
+    build_processor,
+)
+from bionemo_ir.pipeline.stages.configs import WriterStageConfig
+
+config = EngineProcessorConfig(
+    model_source="boltz-2",
+    executor_backend=None,  # serial, in-process
+    writer_stage=WriterStageConfig(output_path="output", format="cif"),
+)
+processor = build_processor(config)
+
+request = InputRequest(
+    input_id="demo",
+    polymers=[
+        Polymer(
+            polymer_type="protein",
+            chain_id=["A"],
+            sequence="GSHMSL...",
+            msas=[MSARecord(path="msa.a3m", format="a3m")],
+        )
+    ],
+)
+outputs = processor([{"record": request, "__record_id": request["input_id"]}])
+# outputs[0]["output_path"] -> output/demo.cif
+```
+
+## Next steps
+
+- [API reference](../development/ref/api.md) — `build_processor` in detail,
+  model constructors, inputs/outputs, Ray multi-GPU execution.
+- [Support matrix](../development/ref/support-matrix.md) — models, GPUs,
+  and fused kernels.
+- [Model weights](../development/ref/model-weights.md) — checkpoint
+  resolution and staging.
+- [Architecture](../development/ref/architecture.md) — the five-stage
+  pipeline and runtime design.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,0 +1,27 @@
+# BioNeMo Inference Runtime
+
+Easy, fast, and memory-efficient structure-prediction inference.
+GPU-accelerated pipelines turn FASTA/MSA inputs into PDB/mmCIF structures
+with confidence scores — for protein, nucleic-acid, and ligand models.
+Models stay ordinary `nn.Module`s; there is no TensorRT engine build.
+
+## Where to go
+
+- [Quickstart](guides/quickstart.md) — install BioIR and fold your first
+  sequence.
+- [API Reference](reference/bionemo_ir/index.md) — every module of the
+  `bionemo_ir` package, generated from docstrings.
+- [Developer Docs](development/index.md) — build from source, pipeline
+  architecture, config tree, support matrix, and contribution rules.
+- [GitHub repository](https://github.com/NVIDIA-BioNeMo/BioNeMo-Inference-Runtime)
+  — source code, issues, and discussions.
+
+## Supported models
+
+- Boltz-1 / Boltz-2
+- OpenFold2 / AlphaFold2
+- OpenFold3
+- Protenix
+
+Per-model data coverage, GPU SKUs, and fused kernels:
+[support matrix](development/ref/support-matrix.md).

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -1,0 +1,81 @@
+# MkDocs configuration for the BioIR documentation website.
+# Preview from the repo root:  mkdocs serve -f website/mkdocs.yml
+site_name: BioNeMo Inference Runtime
+site_description: GPU-accelerated inference for biomolecular structure prediction
+site_url: https://nvidia-bionemo.github.io/BioNeMo-Inference-Runtime/
+repo_url: https://github.com/NVIDIA-BioNeMo/BioNeMo-Inference-Runtime
+# Pages come from two sources (website/docs and the repo's docs/ tree), so a
+# single "edit this page" target would be wrong half the time. Disabled.
+edit_uri: ""
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: green
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: green
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - content.code.copy
+
+plugins:
+  - search
+  - gen-files:
+      scripts:
+        - scripts/import_docs.py
+        - scripts/gen_ref_pages.py
+  - literate-nav
+  - mkdocstrings:
+      handlers:
+        python:
+          # Resolved against this config file's directory: the repo root,
+          # where the bionemo_ir package lives. Griffe parses the sources
+          # statically — torch/CUDA/Ray are never imported during the build.
+          paths: [".."]
+          options:
+            docstring_style: google
+            members_order: source
+            separate_signature: true
+            show_root_heading: true
+            show_signature_annotations: true
+            show_source: false
+
+# literate-nav expands directory references via their generated SUMMARY.md.
+nav:
+  - Home: index.md
+  - Guides:
+      - Quickstart: guides/quickstart.md
+  - API Reference: reference/
+  - Developer Docs: development/
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        # Mermaid.js ships with Material; this makes ```mermaid fences render.
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true

--- a/website/plan.md
+++ b/website/plan.md
@@ -1,0 +1,56 @@
+# Website plan
+
+What is done and what comes next for the BioNeMo Inference Runtime (BioIR)
+documentation site. Build and preview instructions: [README.md](README.md).
+
+## Done
+
+- MkDocs Material + mkdocstrings scaffold under `website/`.
+- API reference generated from docstrings (static griffe parse — no GPU
+  stack needed to build).
+- `docs/` imported at build time into "Developer Docs" with link rewriting;
+  `docs/` itself untouched. `docs/nv/` excluded (internal process docs).
+- Landing page, quickstart guide, Mermaid diagrams.
+- Lint-clean under the repo's ruff / rumdl rules.
+
+## Next steps
+
+### CI/CD (GitHub Pages)
+
+- [ ] Add `.github/workflows/docs.yml` (the repo's first workflow):
+  - PRs touching `website/**`, `docs/**`, `bionemo_ir/**`: build-only check
+    with `mkdocs build -f website/mkdocs.yml`.
+  - Pushes to `main`: build, then deploy via `actions/upload-pages-artifact`
+    plus `actions/deploy-pages`.
+- [ ] Enable Pages in the GitHub repo settings (source: GitHub Actions).
+- [ ] The workflow lands in internal GitLab first and mirrors out via
+  Copybara; the deploy job only runs on the GitHub side.
+
+### Versioning
+
+- [ ] Add `mike` to `website/requirements.txt` and deploy per release
+  (`mike deploy <version>`) once the first public release is cut.
+
+### Content
+
+- [ ] More guides under `website/docs/guides/`: Ray multi-GPU inference,
+  custom-module onboarding (`.agents/skills/module-onboard/`), pairwise
+  memory optimizations (`.agents/skills/scan-mem-opt-patterns/`).
+- [ ] Landing-page branding: logo, `overrides/` theme partials.
+
+### API reference
+
+- [ ] Add `__init__.py` to `bionemo_ir/_torch/modules/openfold3/utils/` so
+  its four modules get pages (skipped today — griffe cannot traverse
+  namespace dirs). Decide whether `dsl_kernels/cute/` stays excluded.
+- [ ] Fix the docstring nits griffe warns about (mismatched parameter names
+  in `openfold2/structure.py`, `openfold3/embedders.py`, and friends).
+- [ ] If the reference nav feels too deep, curate which `_torch` internals
+  get pages.
+
+### Nice to have
+
+- [ ] Edit-this-page links: needs per-source paths (`edit_uri` for
+  hand-written pages, `mkdocs_gen_files.set_edit_path` for generated ones).
+- [ ] C++/CUDA kernel docs via Doxygen, if `cpp/` ever needs a public API
+  reference.

--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs-material>=9.5
+mkdocstrings[python]>=0.26
+mkdocs-gen-files>=0.5
+mkdocs-literate-nav>=0.6
+ruff>=0.6  # mkdocstrings uses it to format signatures

--- a/website/scripts/gen_ref_pages.py
+++ b/website/scripts/gen_ref_pages.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate the API reference: one virtual page per ``bionemo_ir`` module.
+
+Runs inside the MkDocs build via mkdocs-gen-files (see ``mkdocs.yml``); the
+pages never touch the checkout. Griffe parses the sources statically, so the
+GPU stack that ``bionemo_ir`` imports at runtime is not needed to build docs.
+
+Modules under namespace directories (no ``__init__.py``, e.g.
+``dsl_kernels/cute/``) are skipped: griffe's static resolver cannot attach
+them to their parent package. They are listed in a build warning.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import mkdocs_gen_files
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE = "bionemo_ir"
+
+log = logging.getLogger("mkdocs.plugins.gen_files")
+
+# Griffe falls back to sys.path for module resolution; make sure the repo
+# root is on it no matter where the mkdocs command is invoked from.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _under_regular_package(path: Path) -> bool:
+    parent = path.parent
+    while parent != REPO_ROOT:
+        if not (parent / "__init__.py").exists():
+            return False
+        parent = parent.parent
+    return True
+
+
+nav = mkdocs_gen_files.Nav()
+skipped: list[str] = []
+
+for path in sorted((REPO_ROOT / PACKAGE).rglob("*.py")):
+    if not _under_regular_package(path):
+        skipped.append(path.relative_to(REPO_ROOT).as_posix())
+        continue
+    module_path = path.relative_to(REPO_ROOT).with_suffix("")
+    doc_path = module_path.with_suffix(".md")
+    parts = tuple(module_path.parts)
+
+    if parts[-1] == "__main__":
+        continue
+    is_package = parts[-1] == "__init__"
+    if is_package:
+        parts = parts[:-1]
+        doc_path = doc_path.with_name("index.md")
+    if not parts:
+        continue
+
+    full_doc_path = Path("reference", doc_path)
+    nav[parts] = doc_path.as_posix()
+
+    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        fd.write(f"::: {'.'.join(parts)}\n")
+        if is_package:
+            # Re-exported members are documented on their defining module's
+            # page; rendering them here too would duplicate anchors.
+            fd.write("    options:\n      show_submodules: true\n      members: []\n")
+
+if skipped:
+    log.warning("skipping modules under namespace directories (no __init__.py):\n  " + "\n  ".join(skipped))
+
+with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+    nav_file.writelines(nav.build_literate_nav())

--- a/website/scripts/import_docs.py
+++ b/website/scripts/import_docs.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import the repo's ``docs/`` tree into the site as virtual pages.
+
+``docs/`` is written for GitHub rendering and must stay untouched, so the
+import happens at build time (mkdocs-gen-files). Files are copied verbatim
+except for link rewriting: links that escape ``docs/`` (to source files,
+examples, or the repo README) would 404 on the rendered site, so they are
+rewritten to absolute GitHub URLs. Links between imported files are left
+alone — the tree structure is preserved under ``development/``, so they keep
+resolving inside the site.
+"""
+
+import re
+from pathlib import Path
+
+import mkdocs_gen_files
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = REPO_ROOT / "docs"
+TARGET_DIR = "development"
+GITHUB_REPO = "https://github.com/NVIDIA-BioNeMo/BioNeMo-Inference-Runtime"
+
+# docs/nv/ holds NVIDIA-internal release/process docs; keep them off the
+# public site. Links from imported files into it are rewritten to GitHub.
+EXCLUDED_TOP_DIRS = {"nv"}
+
+_DIR_TITLES = {"ref": "Reference"}
+_INLINE_LINK = re.compile(r"\]\(([^)]+)\)")
+_REF_DEF = re.compile(r"^(\s*\[[^\]]+\]:\s*)(\S+)", re.MULTILINE)
+_HEADING = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+
+
+def _github_url(repo_rel: str) -> str:
+    kind = "blob" if "." in repo_rel.rsplit("/", 1)[-1] else "tree"
+    return f"{GITHUB_REPO}/{kind}/main/{repo_rel}"
+
+
+def _rewrite_target(target: str, source: Path) -> str:
+    if "://" in target or target.startswith(("#", "mailto:")):
+        return target
+    path, _, anchor = target.partition("#")
+    if not path:
+        return target
+    resolved = (source.parent / path).resolve()
+    if not resolved.is_relative_to(REPO_ROOT):
+        return target
+    if resolved.is_relative_to(DOCS_DIR):
+        if resolved.relative_to(DOCS_DIR).parts[0] not in EXCLUDED_TOP_DIRS:
+            # README.md is imported as index.md; keep in-tree links resolving.
+            if resolved.name == "README.md":
+                suffix = f"#{anchor}" if anchor else ""
+                return path[: -len("README.md")] + "index.md" + suffix
+            return target
+    suffix = f"#{anchor}" if anchor else ""
+    return _github_url(resolved.relative_to(REPO_ROOT).as_posix()) + suffix
+
+
+def _rewrite_inline(match: re.Match[str], source: Path) -> str:
+    parts = match.group(1).split(None, 1)
+    target = _rewrite_target(parts[0], source)
+    return "](" + target + (" " + parts[1] if len(parts) > 1 else "") + ")"
+
+
+def _title_of(content: str, fallback: str) -> str:
+    match = _HEADING.search(content)
+    return match.group(1).strip() if match else fallback
+
+
+def main() -> None:
+    nav = mkdocs_gen_files.Nav()
+    for path in sorted(DOCS_DIR.rglob("*.md")):
+        rel = path.relative_to(DOCS_DIR)
+        if rel.parts[0] in EXCLUDED_TOP_DIRS:
+            continue
+        dest = rel.with_name("index.md") if rel.name == "README.md" else rel
+        content = path.read_text(encoding="utf-8")
+        content = _INLINE_LINK.sub(lambda m, p=path: _rewrite_inline(m, p), content)
+        content = _REF_DEF.sub(lambda m, p=path: m.group(1) + _rewrite_target(m.group(2), p), content)
+        with mkdocs_gen_files.open(Path(TARGET_DIR, dest), "w") as fd:
+            fd.write(content)
+        title = "Overview" if rel == Path("README.md") else _title_of(content, rel.stem)
+        key = tuple(_DIR_TITLES.get(d, d) for d in dest.parent.parts if d != ".") + (title,)
+        nav[key] = dest.as_posix()
+    with mkdocs_gen_files.open(Path(TARGET_DIR, "SUMMARY.md"), "w") as nav_file:
+        nav_file.writelines(nav.build_literate_nav())
+
+
+main()


### PR DESCRIPTION
## Description

Adds a documentation website for `bionemo_ir` under `website/`, built with
[MkDocs Material](https://squidfunk.github.io/mkdocs-material/) +
[mkdocstrings](https://mkdocstrings.github.io/) — the same stack as
[bionemo-recipes](https://github.com/NVIDIA-BioNeMo/bionemo-recipes/tree/main/docs).
The existing `docs/` tree is left untouched.

- **API reference**: one page per `bionemo_ir` module, generated at build
  time from the Google-style docstrings. griffe parses the sources
  statically, so the docs build needs no GPU, torch, or Ray (~16 s).
- **Developer Docs section**: the `docs/` tree is imported as virtual
  pages at build time. Links between docs files keep working in-site;
  links escaping `docs/` (source files, examples) are rewritten to
  absolute GitHub URLs. `docs/nv/` is excluded as internal process docs.
- **Content**: landing page, quickstart guide, Mermaid diagram support.
- Local preview:
  `pip install -r website/requirements.txt && mkdocs serve -f website/mkdocs.yml`

GitHub Pages deployment (CI) is deliberately **not** included in this PR;
next steps are tracked in `website/plan.md`.

Draft: no JIRA / NVBug ticket exists for this work — a tracker key can be
added to the title before undrafting if required.

Verified locally: `mkdocs build` succeeds; new files pass `ruff check`,
`ruff format --check`, and `rumdl` (via a website-scoped `.rumdl.toml`).

## Type of change

- [x] Documentation

## Checklist

- [x] My commits are signed off (DCO): `git commit -s` (see
     [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] For a new feature or breaking change, an issue was filed and approved
     first (N/A — documentation)
- [ ] I added or updated tests, and they pass locally (N/A — docs build
     verified instead)
- [x] I updated documentation as needed